### PR TITLE
Added task page route - initial changes

### DIFF
--- a/internal/handlers/tasks/tasks.go
+++ b/internal/handlers/tasks/tasks.go
@@ -62,6 +62,56 @@ func Load(ctx *gin.Context) {
 	}
 }
 
+func LoadTask(ctx *gin.Context) {
+	db := app.GetUserDatabase(ctx)
+	log := app.GetLogger(ctx)
+
+	taskID := ctx.Param("taskID")
+	if taskID == "" {
+		app.ErrorBadRequestHTML(ctx, "Task ID must not be empty.")
+		return
+	}
+
+	task, err := db.Task(taskID)
+	if err != nil {
+		log.Error("error handling task", "taskID", taskID, "error", err)
+		app.ErrorInternalHTML(ctx, "Failed to load task.")
+		return
+	}
+
+	subtasks, err := db.Subtasks(task.ID)
+	if err != nil {
+		log.Error("error fetching subtasks", "taskID", taskID, "error", err)
+		app.ErrorInternalHTML(ctx, "Failed to load subtasks.")
+		return
+	}
+
+	allLists, err := db.Lists("")
+	if err != nil {
+		log.Error("error fetching lists", "error", err)
+		app.ErrorInternalHTML(ctx, "Failed to load lists.")
+		return
+	}
+	var realLists []*database.List
+	for _, l := range allLists {
+		if l.FilterBy == "" {
+			realLists = append(realLists, l)
+		}
+	}
+
+	ctx.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+	err = web.Render(ctx.Writer, "task-page", map[string]any{
+		"Task":      task,
+		"Subtasks":  subtasks,
+		"Lists":     realLists,
+		"CSRFToken": app.GetCSRFToken(ctx),
+	})
+	if err != nil {
+		log.Error("error rendering task-page", "error", err)
+		app.ErrorInternalHTML(ctx, "Failed to render task.")
+	}
+}
+
 func GetTasks(ctx *gin.Context) {
 	db := app.GetUserDatabase(ctx)
 	log := app.GetLogger(ctx)

--- a/internal/router/tasks.go
+++ b/internal/router/tasks.go
@@ -11,6 +11,7 @@ import (
 func TasksRoutes(router *gin.Engine, application *app.App) {
 	// Navigation routes
 	router.GET("/tasks", middleware.UserMiddleware(application), middleware.CSRFMiddleware(), taskhandlers.Load)
+	router.GET("/task/:taskID", middleware.UserMiddleware(application), middleware.CSRFMiddleware(), taskhandlers.LoadTask)
 
 	// Partials: returns HTML chunks
 	partials := router.Group("/partials", middleware.UserMiddleware(application), middleware.CSRFMiddleware())

--- a/web/templates/apps/tasks/app.html
+++ b/web/templates/apps/tasks/app.html
@@ -1,4 +1,18 @@
-{{define "app-styles"}}
+{{define "task-page"}}
+<!doctype html>
+<html lang="en">
+    <head>
+        {{template "meta"}}
+        <meta name="csrf-token" content="{{.CSRFToken}}" />
+        <link href="/assets/css/dist/tasks.min.css" rel="stylesheet" />
+        <script src="/assets/js/dist/tasks.min.js" type="module"></script>
+    </head>
+    <body>
+        {{template "header"}}
+        <main class="task-page">{{template "details" .}}</main>
+    </body>
+</html>
+{{end}} {{define "app-styles"}}
 <meta name="csrf-token" content="{{.CSRFToken}}" />
 <link href="/assets/css/dist/tasks.min.css" rel="stylesheet" />
 <script src="/assets/js/libs/htmx.min.js"></script>


### PR DESCRIPTION
# THIS IS A TEST OF DEV IDEAS

## Add `/task/:id` full-page route

- `internal/router/tasks.go` — added `GET /task/:taskID` route
- `internal/handlers/tasks/tasks.go` — added `LoadTask` handler (fetches task, subtasks, and lists; renders full page)
- `web/templates/apps/tasks/app.html` — added `task-page` template (standalone HTML page wrapping the existing `details` template)